### PR TITLE
Add support for token streaming, parallel jobs and custom CORS

### DIFF
--- a/fastmlx/fastmlx.py
+++ b/fastmlx/fastmlx.py
@@ -9,7 +9,7 @@ from urllib.parse import unquote
 
 from fastapi import FastAPI, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 try:
@@ -22,6 +22,7 @@ try:
     from .utils import (
         MODEL_REMAPPING,
         MODELS,
+        SupportedModels,
         lm_stream_generator,
         load_lm_model,
         load_vlm_model,
@@ -222,6 +223,14 @@ async def chat_completion(request: ChatCompletionRequest):
     )
 
     return response
+
+
+@app.get("/v1/supported_models", response_model=SupportedModels)
+async def get_supported_models():
+    """
+    Get a list of supported model types for VLM and LM.
+    """
+    return JSONResponse(content=MODELS)
 
 
 @app.get("/v1/models")

--- a/fastmlx/fastmlx.py
+++ b/fastmlx/fastmlx.py
@@ -36,7 +36,7 @@ class ModelProvider:
     def __init__(self):
         self.models = {}
 
-    def load_model(self, model_name: str):
+    async def load_model(self, model_name: str):
         if model_name not in self.models:
             config = load_config(model_name)
             model_type = MODEL_REMAPPING.get(config["model_type"], config["model_type"])
@@ -97,7 +97,7 @@ async def chat_completion(request: ChatCompletionRequest):
         raise HTTPException(status_code=500, detail="MLX library not available")
 
     stream = request.stream
-    model_data = model_provider.load_model(request.model)
+    model_data = await model_provider.load_model(request.model)
     model = model_data["model"]
     config = model_data["config"]
     model_type = MODEL_REMAPPING.get(config["model_type"], config["model_type"])

--- a/fastmlx/fastmlx.py
+++ b/fastmlx/fastmlx.py
@@ -36,7 +36,7 @@ class ModelProvider:
     def __init__(self):
         self.models = {}
 
-    async def load_model(self, model_name: str):
+    def load_model(self, model_name: str):
         if model_name not in self.models:
             config = load_config(model_name)
             model_type = MODEL_REMAPPING.get(config["model_type"], config["model_type"])
@@ -97,7 +97,7 @@ async def chat_completion(request: ChatCompletionRequest):
         raise HTTPException(status_code=500, detail="MLX library not available")
 
     stream = request.stream
-    model_data = await model_provider.load_model(request.model)
+    model_data = model_provider.load_model(request.model)
     model = model_data["model"]
     config = model_data["config"]
     model_type = MODEL_REMAPPING.get(config["model_type"], config["model_type"])

--- a/fastmlx/fastmlx.py
+++ b/fastmlx/fastmlx.py
@@ -238,13 +238,21 @@ def run():
     parser.add_argument(
         "--port", type=int, default=8000, help="Port to run the server on"
     )
+    parser.add_argument("--workers", type=int, default=None, help="Number of workers")
     args = parser.parse_args()
 
     setup_cors(app, args.allowed_origins)
 
     import uvicorn
 
-    uvicorn.run("fastmlx:app", host=args.host, port=args.port, reload=True)
+    uvicorn.run(
+        "fastmlx:app",
+        host=args.host,
+        port=args.port,
+        reload=False,
+        workers=args.workers,
+        loop="asyncio",
+    )
 
 
 if __name__ == "__main__":

--- a/fastmlx/utils.py
+++ b/fastmlx/utils.py
@@ -1,12 +1,14 @@
-import os
 import json
-from typing import Any, Dict, List, Optional
+import os
 import time
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel
 
 # MLX Imports
 try:
-    from mlx_lm import load as lm_load, models as lm_models
+    from mlx_lm import load as lm_load
+    from mlx_lm import models as lm_models
     from mlx_lm.utils import stream_generate as lm_stream_generate
     from mlx_vlm import load as vlm_load
     from mlx_vlm import models as vlm_models
@@ -72,6 +74,7 @@ def load_lm_model(model_name: str, config: Dict[str, Any]) -> Dict[str, Any]:
     model, tokenizer = lm_load(model_name)
     return {"model": model, "tokenizer": tokenizer, "config": config}
 
+
 # TODO: Replace on next mlx-vlm release
 def vlm_stream_generate(
     model,
@@ -127,8 +130,25 @@ def vlm_stream_generate(
         yield detokenizer.last_segment
 
 
-def vlm_stream_generator(model, model_name, processor, image, prompt, image_processor, max_tokens, temperature):
-    for token in vlm_stream_generate(model, processor, image, prompt, image_processor, max_tokens=max_tokens, temp=temperature):
+def vlm_stream_generator(
+    model,
+    model_name,
+    processor,
+    image,
+    prompt,
+    image_processor,
+    max_tokens,
+    temperature,
+):
+    for token in vlm_stream_generate(
+        model,
+        processor,
+        image,
+        prompt,
+        image_processor,
+        max_tokens=max_tokens,
+        temp=temperature,
+    ):
         chunk = ChatCompletionChunk(
             id=f"chatcmpl-{os.urandom(4).hex()}",
             created=int(time.time()),
@@ -146,7 +166,9 @@ def vlm_stream_generator(model, model_name, processor, image, prompt, image_proc
 
 
 def lm_stream_generator(model, model_name, tokenizer, prompt, max_tokens, temperature):
-    for token in lm_stream_generate(model, tokenizer, prompt, max_tokens=max_tokens, temp=temperature):
+    for token in lm_stream_generate(
+        model, tokenizer, prompt, max_tokens=max_tokens, temp=temperature
+    ):
         chunk = ChatCompletionChunk(
             id=f"chatcmpl-{os.urandom(4).hex()}",
             created=int(time.time()),

--- a/fastmlx/utils.py
+++ b/fastmlx/utils.py
@@ -1,15 +1,31 @@
 import os
-from typing import Any, Dict
+import json
+from typing import Any, Dict, List, Optional
+import time
+from pydantic import BaseModel
 
 # MLX Imports
 try:
-    from mlx_lm import load as lm_load
-    from mlx_lm import models as lm_models
+    from mlx_lm import load as lm_load, models as lm_models
+    from mlx_lm.utils import stream_generate as lm_stream_generate
     from mlx_vlm import load as vlm_load
     from mlx_vlm import models as vlm_models
-    from mlx_vlm.utils import load_image_processor
+    from mlx_vlm.utils import (
+        generate_step,
+        load_image_processor,
+        prepare_inputs,
+        sample,
+    )
 except ImportError:
     print("Warning: mlx or mlx_lm not available. Some functionality will be limited.")
+
+
+class ChatCompletionChunk(BaseModel):
+    id: str
+    object: str = "chat.completion.chunk"
+    created: int
+    model: str
+    choices: List[Dict[str, Any]]
 
 
 def get_model_type_list(models, type="vlm"):
@@ -55,3 +71,93 @@ def load_vlm_model(model_name: str, config: Dict[str, Any]) -> Dict[str, Any]:
 def load_lm_model(model_name: str, config: Dict[str, Any]) -> Dict[str, Any]:
     model, tokenizer = lm_load(model_name)
     return {"model": model, "tokenizer": tokenizer, "config": config}
+
+# TODO: Replace on next mlx-vlm release
+def vlm_stream_generate(
+    model,
+    processor,
+    image: str,
+    prompt: str,
+    image_processor=None,
+    max_tokens: int = 100,
+    temp: float = 0.0,
+    repetition_penalty: Optional[float] = None,
+    repetition_context_size: Optional[int] = None,
+    top_p: float = 1.0,
+):
+
+    if image_processor is not None:
+        tokenizer = processor
+    else:
+        tokenizer = processor.tokenizer
+
+    image_token_index = model.config.image_token_index
+    input_ids, pixel_values, mask = prepare_inputs(
+        image_processor, processor, image, prompt, image_token_index
+    )
+    logits, cache = model(input_ids, pixel_values, mask=mask)
+    logits = logits[:, -1, :]
+    y, _ = sample(logits, temp, top_p)
+
+    detokenizer = processor.detokenizer
+    detokenizer.reset()
+
+    detokenizer.add_token(y.item())
+
+    for (token, _), n in zip(
+        generate_step(
+            model.language_model,
+            logits,
+            mask,
+            cache,
+            temp,
+            repetition_penalty,
+            repetition_context_size,
+            top_p,
+        ),
+        range(max_tokens),
+    ):
+        token = token.item()
+
+        if token == tokenizer.eos_token_id:
+            break
+
+        detokenizer.add_token(token)
+        detokenizer.finalize()
+        yield detokenizer.last_segment
+
+
+def vlm_stream_generator(model, model_name, processor, image, prompt, image_processor, max_tokens, temperature):
+    for token in vlm_stream_generate(model, processor, image, prompt, image_processor, max_tokens=max_tokens, temp=temperature):
+        chunk = ChatCompletionChunk(
+            id=f"chatcmpl-{os.urandom(4).hex()}",
+            created=int(time.time()),
+            model=model_name,
+            choices=[
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": token},
+                    "finish_reason": None,
+                }
+            ],
+        )
+        yield f"data: {json.dumps(chunk.model_dump())}\n\n"
+    yield "data: [DONE]\n\n"
+
+
+def lm_stream_generator(model, model_name, tokenizer, prompt, max_tokens, temperature):
+    for token in lm_stream_generate(model, tokenizer, prompt, max_tokens=max_tokens, temp=temperature):
+        chunk = ChatCompletionChunk(
+            id=f"chatcmpl-{os.urandom(4).hex()}",
+            created=int(time.time()),
+            model=model_name,
+            choices=[
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": token},
+                    "finish_reason": None,
+                }
+            ],
+        )
+        yield f"data: {json.dumps(chunk.model_dump())}\n\n"
+    yield "data: [DONE]\n\n"

--- a/fastmlx/utils.py
+++ b/fastmlx/utils.py
@@ -30,6 +30,11 @@ class ChatCompletionChunk(BaseModel):
     choices: List[Dict[str, Any]]
 
 
+class SupportedModels(BaseModel):
+    vlm: List[str]
+    lm: List[str]
+
+
 def get_model_type_list(models, type="vlm"):
 
     # Get the directory path of the models package
@@ -48,7 +53,8 @@ def get_model_type_list(models, type="vlm"):
         ]
         return submodules
     else:
-        return all_items
+
+        return [item for item in all_items if not item.startswith("__")]
 
 
 MODELS = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastmlx"
-version = "0.0.1"
+version = "0.1.0"
 dynamic = [
     "dependencies",
 ]
@@ -52,7 +52,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.0.1"
+current_version = "0.1.0"
 commit = true
 tag = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = [
     "fastmlx",
     "MLX",
     "Apple MLX",
-    "vision language models"
+    "vision language models",
     "VLMs",
     "large language models",
     "LLMs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,12 @@ readme = "README.md"
 requires-python = ">=3.8"
 keywords = [
     "fastmlx",
+    "MLX",
+    "Apple MLX",
+    "vision language models"
+    "VLMs",
+    "large language models",
+    "LLMs",
 ]
 license = {text = "Apache Software License 2.0"}
 authors = [
@@ -34,7 +40,7 @@ all = [
 ]
 
 extra = [
-    "pandas",
+    "",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,7 @@ all = [
     "fastmlx[extra]",
 ]
 
-extra = [
-    "",
-]
+extra = []
 
 
 [tool]

--- a/tests/test_fastmlx.py
+++ b/tests/test_fastmlx.py
@@ -174,6 +174,16 @@ async def test_lm_streaming(client):
     assert chunks[-2] == "data: [DONE]"
 
 
+def test_get_supported_models(client):
+    response = client.get("/v1/supported_models")
+    assert response.status_code == 200
+    data = response.json()
+    assert "vlm" in data
+    assert "lm" in data
+    assert data["vlm"] == ["llava"]
+    assert data["lm"] == ["phi"]
+
+
 def test_list_models(client):
     client.post("/v1/models?model_name=test_llava_model")
     client.post("/v1/models?model_name=test_phi_model")

--- a/tests/test_fastmlx.py
+++ b/tests/test_fastmlx.py
@@ -30,7 +30,13 @@ class MockModelProvider(ModelProvider):
             }
         return self.models[model_name]
 
-    def get_available_models(self):
+    async def remove_model(self, model_name: str) -> bool:
+        if model_name in self.models:
+            del self.models[model_name]
+            return True
+        return False
+
+    async def get_available_models(self):
         return list(self.models.keys())
 
 
@@ -43,6 +49,18 @@ def mock_generate(*args, **kwargs):
     return "generated response"
 
 
+def mock_vlm_stream_generate(*args, **kwargs):
+    yield "Hello"
+    yield " world"
+    yield "!"
+
+
+def mock_lm_stream_generate(*args, **kwargs):
+    yield "Testing"
+    yield " stream"
+    yield " generation"
+
+
 @pytest.fixture(scope="module")
 def client():
     # Apply patches
@@ -50,6 +68,10 @@ def client():
         "fastmlx.fastmlx.vlm_generate", mock_generate
     ), patch("fastmlx.fastmlx.lm_generate", mock_generate), patch(
         "fastmlx.fastmlx.MODELS", MODELS
+    ), patch(
+        "fastmlx.utils.vlm_stream_generate", mock_vlm_stream_generate
+    ), patch(
+        "fastmlx.utils.lm_stream_generate", mock_lm_stream_generate
     ):
         yield TestClient(app)
 
@@ -80,6 +102,78 @@ def test_chat_completion_lm(client):
     assert "generated response" in response.json()["choices"][0]["message"]["content"]
 
 
+@pytest.mark.asyncio
+async def test_vlm_streaming(client):
+
+    # Mock the vlm_stream_generate function
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test_llava_model",
+            "messages": [{"role": "user", "content": "Describe this image"}],
+            "image": "base64_encoded_image_data",
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+
+    chunks = list(response.iter_lines())
+    assert len(chunks) == 8  # 7 content chunks + [DONE]
+    for chunk in chunks[:-2]:  # Exclude the [DONE] message
+        if chunk:
+            chunk = chunk.split("data: ")[1]
+            data = json.loads(chunk)
+            assert "id" in data
+            assert data["object"] == "chat.completion.chunk"
+            assert "created" in data
+            assert data["model"] == "test_llava_model"
+            assert len(data["choices"]) == 1
+            assert data["choices"][0]["index"] == 0
+            assert "delta" in data["choices"][0]
+            assert "role" in data["choices"][0]["delta"]
+            assert "content" in data["choices"][0]["delta"]
+
+    assert chunks[-2] == "data: [DONE]"
+
+
+@pytest.mark.asyncio
+async def test_lm_streaming(client):
+
+    # Mock the lm_stream_generate function
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test_phi_model",
+            "messages": [{"role": "user", "content": "Hello, how are you?"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+
+    chunks = list(response.iter_lines())
+    assert len(chunks) == 8  # 7 content chunks + [DONE]
+
+    for chunk in chunks[:-2]:  # Exclude the [DONE] message
+        if chunk:
+            chunk = chunk.split("data: ")[1]
+            data = json.loads(chunk)
+            assert "id" in data
+            assert data["object"] == "chat.completion.chunk"
+            assert "created" in data
+            assert data["model"] == "test_phi_model"
+            assert len(data["choices"]) == 1
+            assert data["choices"][0]["index"] == 0
+            assert "delta" in data["choices"][0]
+            assert "role" in data["choices"][0]["delta"]
+            assert "content" in data["choices"][0]["delta"]
+
+    assert chunks[-2] == "data: [DONE]"
+
+
 def test_list_models(client):
     client.post("/v1/models?model_name=test_llava_model")
     client.post("/v1/models?model_name=test_phi_model")
@@ -98,6 +192,29 @@ def test_add_model(client):
         "status": "success",
         "message": "Model new_llava_model added successfully",
     }
+
+
+def test_remove_model(client):
+    # Add a model
+    response = client.post("/v1/models?model_name=test_model")
+    assert response.status_code == 200
+
+    # Verify the model is added
+    response = client.get("/v1/models")
+    assert "test_model" in response.json()["models"]
+
+    # Remove the model
+    response = client.delete("/v1/models?model_name=test_model")
+    assert response.status_code == 204
+
+    # Verify the model is removed
+    response = client.get("/v1/models")
+    assert "test_model" not in response.json()["models"]
+
+    # Try to remove a non-existent model
+    response = client.delete("/v1/models?model_name=non_existent_model")
+    assert response.status_code == 404
+    assert "Model 'non_existent_model' not found" in response.json()["detail"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds: 

1. Multi-modal token streaming.
2. Support for Parallel calls (single and multiple models) by default upto N workers.
3. Supported model type endpoint.
4. Delete model endpoint.
5. Custome CORS.

Todo: 

- [ ] Refactor stream_generate after mlx-vlm's next release

Closes #2, Closes #5 