### PR TITLE
Fixed default prompt template in config.json

### DIFF
--- a/fastmlx/tools/config.json
+++ b/fastmlx/tools/config.json
@@ -22,7 +22,7 @@
       "tool_role": "tool"
     },
     "default": {
-      "prompt_template": "llama3_1.j2",
+      "prompt_template": "llama-3_1.j2",
       "parallel_tool_calling": false
     }
   }


### PR DESCRIPTION
llama3_1.j2 changed to llama-3_1.j2 so it doesn't throw an error when trying to use the default template