### PR TITLE
Update utils.py

### DIFF
--- a/fastmlx/utils.py
+++ b/fastmlx/utils.py
@@ -444,7 +444,10 @@ def lm_stream_generator(
     ):
         if stop_words and token in stop_words:
             break
-
+        # the return type of lm_stream_generate is mlx_lm.GenerationResponse, 
+        # which includes a mx.array field and will get pydantic model_dump failed.
+        token = token.text
+        
         # Update token length info
         if INCLUDE_USAGE:
             completion_tokens += 1

--- a/fastmlx/utils.py
+++ b/fastmlx/utils.py
@@ -439,18 +439,57 @@ def lm_stream_generator(
     completion_tokens = 0
     empty_usage: Usage = None
 
+    import numpy as np
+    from dataclasses import dataclass
+    from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type, Union
+    @dataclass
+    class MyGenerationResponse:
+        """
+        The modified output of :func:`mlx_lm.utils.stream_generate`.
+
+        Args:
+            text (str): The next segment of decoded text. This can be an empty string.
+            token (int): The next token.
+            logprobs []: A vector of log probabilities.
+            prompt_tokens (int): The number of tokens in the prompt.
+            prompt_tps (float): The prompt processing tokens-per-second.
+            generation_tokens (int): The number of generated tokens.
+            generation_tps (float): The tokens-per-second for generation.
+            peak_memory (float): The peak memory used so far in GB.
+            finish_reason (str): The reason the response is being sent: "length", "stop" or `None`
+        """
+
+        text: str
+        token: int
+        logprobs: []
+        prompt_tokens: int
+        prompt_tps: float
+        generation_tokens: int
+        generation_tps: float
+        peak_memory: float
+        finish_reason: Optional[str] = None
+
     for token in lm_stream_generate(
         model, tokenizer, prompt, max_tokens=max_tokens, temp=temperature
     ):
         if stop_words and token in stop_words:
             break
-        # the return type of lm_stream_generate is mlx_lm.GenerationResponse, 
-        # which includes a mx.array field and will get pydantic model_dump failed.
-        token = token.text
-        
+
         # Update token length info
         if INCLUDE_USAGE:
             completion_tokens += 1
+        
+        token = MyGenerationResponse(
+                text=token.text,
+                token=token.token,
+                logprobs=np.array(token.logprobs).tolist(),
+                prompt_tokens=token.prompt_tokens,
+                prompt_tps=token.prompt_tps,
+                generation_tokens=token.generation_tokens,
+                generation_tps=token.generation_tps,
+                peak_memory=token.peak_memory,
+                finish_reason=token.finish_reason
+        )
 
         chunk = ChatCompletionChunk(
             id=f"chatcmpl-{os.urandom(4).hex()}",


### PR DESCRIPTION
in the function lm_stream_generator, the token returned by mlx_lm.lm_stream_generate is a mlx_lm.GenerationResponse, which includes a mx.array field
`
@dataclass
class GenerationResponse:
    """
    The output of :func:`stream_generate`.

    Args:
        text (str): The next segment of decoded text. This can be an empty string.
        token (int): The next token.
        logprobs (mx.array): A vector of log probabilities.
        prompt_tokens (int): The number of tokens in the prompt.
        prompt_tps (float): The prompt processing tokens-per-second.
        generation_tokens (int): The number of generated tokens.
        generation_tps (float): The tokens-per-second for generation.
        peak_memory (float): The peak memory used so far in GB.
        finish_reason (str): The reason the response is being sent: "length", "stop" or `None`
    """

    text: str
    token: int
    logprobs: mx.array
    prompt_tokens: int
    prompt_tps: float
    generation_tokens: int
    generation_tps: float
    peak_memory: float
    finish_reason: Optional[str] = None
`

As pydantic doesn't support mx.array, it will fail the model_dump() below
`
yield f"data: {json.dumps(chunk.model_dump())}\n\n"
`
